### PR TITLE
feat: deinit method to be able to re-use the same instance

### DIFF
--- a/src/PlayerAnalyticsConnector.ts
+++ b/src/PlayerAnalyticsConnector.ts
@@ -204,6 +204,13 @@ export class PlayerAnalyticsConnector {
     };
   }
 
+  public deinit() {
+    this.stopInterval();
+    this.heartbeatInterval = null;
+    this.videoEventFilter.removeEventListener("*", this.videoEventListener);
+    this.videoEventFilter = null;
+  }
+
   public destroy() {
     this.playerAnalytics.destroy();
     this.heartbeatInterval = null;


### PR DESCRIPTION
If you want to re-use the same instance (without destroying and create a new one) of your analytics connector, already initiated, you should be able to `deinit` and then once again call `init` and `load` with your new _asset_.