### PR TITLE
feat: add optional onError callback for send failures

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,3 +7,8 @@ export {
   PlayerAnalyticsConnector,
   IPlayerAnalyticsConnectorInitOptions,
 } from "./src/PlayerAnalyticsConnector";
+
+export type {
+  TAnalyticsSendError,
+  TOnSendError,
+} from "./src/utils/Reporter";

--- a/spec/PlayerAnalyticsConnector.spec.ts
+++ b/spec/PlayerAnalyticsConnector.spec.ts
@@ -492,4 +492,35 @@ describe("PlayerAnalyticsConnector", () => {
       );
     });
   });
+
+  describe("onError callback", () => {
+    it("should invoke onError callback on send failure", async () => {
+      const errorCallback = jasmine.createSpy("onError");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics",
+        false,
+        errorCallback,
+      );
+      await connector.init({ sessionId: "test-session" });
+
+      // Make subsequent fetches fail with 404
+      mockFetch.and.returnValue(Promise.resolve({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+      }));
+
+      connector.load(mockVideoElement);
+
+      // Trigger a send via reportStop
+      connector.reportStop();
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(errorCallback).toHaveBeenCalledWith(
+        jasmine.objectContaining({ status: 404, statusText: "Not Found" }),
+        jasmine.objectContaining({ event: "stopped" }),
+      );
+    });
+  });
 });

--- a/spec/Reporter.spec.ts
+++ b/spec/Reporter.spec.ts
@@ -306,6 +306,82 @@ describe("Reporter", () => {
       );
     });
 
+    it("should call onError callback on network failure instead of console.warn", async () => {
+      const errorCallback = jasmine.createSpy("onError");
+      const options: IReporterOptions = {
+        eventsinkUrl: "https://example.com/analytics",
+        sessionId: "test-session-id",
+        debug: true,
+        onError: errorCallback,
+      };
+      const reporter = new Reporter(options);
+      await reporter.init();
+
+      (reporter as any).debug = false;
+      mockFetch.calls.reset();
+      mockFetch.and.returnValue(Promise.reject(new Error("Network failure")));
+
+      spyOn(console, "warn");
+
+      const eventData: TPlayerAnalyticsEvent = {
+        event: "playing",
+        sessionId: "test-session-id",
+        timestamp: 1234567890,
+        playhead: 10.5,
+        duration: 120,
+      };
+
+      reporter.send(eventData);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(errorCallback).toHaveBeenCalledWith(
+        { message: "Network failure" },
+        eventData,
+      );
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it("should call onError callback on HTTP 404 instead of console.warn", async () => {
+      const errorCallback = jasmine.createSpy("onError");
+      const options: IReporterOptions = {
+        eventsinkUrl: "https://example.com/analytics",
+        sessionId: "test-session-id",
+        debug: true,
+        onError: errorCallback,
+      };
+      const reporter = new Reporter(options);
+      await reporter.init();
+
+      (reporter as any).debug = false;
+      mockFetch.calls.reset();
+      mockFetch.and.returnValue(Promise.resolve({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+      }));
+
+      spyOn(console, "warn");
+
+      const eventData: TPlayerAnalyticsEvent = {
+        event: "heartbeat",
+        sessionId: "test-session-id",
+        timestamp: 1234567890,
+        playhead: 30,
+        duration: 120,
+      };
+
+      reporter.send(eventData as TPlayerAnalyticsEvent);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(errorCallback).toHaveBeenCalledWith(
+        { status: 404, statusText: "Not Found", message: "Send failed: 404 Not Found" },
+        eventData,
+      );
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
     it("should warn and not send when not initiated", async () => {
       const options: IReporterOptions = {
         eventsinkUrl: "https://example.com/analytics",

--- a/src/PlayerAnalytics.ts
+++ b/src/PlayerAnalytics.ts
@@ -17,7 +17,7 @@ import {
   TWarningEvent,
 } from "@eyevinn/player-analytics-specification";
 import { HEARTBEAT_INTERVAL } from "./utils/constants";
-import { Reporter } from "./utils/Reporter";
+import { Reporter, TOnSendError } from "./utils/Reporter";
 
 export interface IPlayerAnalyticsInitOptions {
   sessionId?: string;
@@ -29,9 +29,11 @@ export class PlayerAnalytics implements PlayerAnalyticsClientModule {
   private debug = false;
   private eventsinkUrl: string;
   private analyticsReporter: Reporter;
-  constructor(eventsinkUrl: string, debug?: boolean) {
+  private onError?: TOnSendError;
+  constructor(eventsinkUrl: string, debug?: boolean, onError?: TOnSendError) {
     this.debug = debug ?? false;
     this.eventsinkUrl = eventsinkUrl;
+    this.onError = onError;
   }
 
   public async initiateAnalyticsReporter({
@@ -45,6 +47,7 @@ export class PlayerAnalytics implements PlayerAnalyticsClientModule {
       debug: this.debug,
       heartbeatInterval,
       shardId,
+      onError: this.onError,
     });
 
     const { sessionId: generatedSessionId, isInitiated } =

--- a/src/PlayerAnalyticsConnector.ts
+++ b/src/PlayerAnalyticsConnector.ts
@@ -4,6 +4,7 @@ import {
   TMediaEventFilter,
 } from "@eyevinn/media-event-filter";
 import { PlayerAnalytics } from "./PlayerAnalytics";
+import { TOnSendError } from "./utils/Reporter";
 import {
   TBaseEvent,
   TBitrateChangedEventPayload,
@@ -33,9 +34,9 @@ export class PlayerAnalyticsConnector {
   private heartbeatInterval: number;
   private heartbeatIntervalTimer: ReturnType<typeof setInterval>;
 
-  constructor(eventsinkUrl: string, debug?: boolean) {
+  constructor(eventsinkUrl: string, debug?: boolean, onError?: TOnSendError) {
     this.eventsinkUrl = eventsinkUrl;
-    this.playerAnalytics = new PlayerAnalytics(this.eventsinkUrl, debug);
+    this.playerAnalytics = new PlayerAnalytics(this.eventsinkUrl, debug, onError);
   }
 
   public async init(options: IPlayerAnalyticsConnectorInitOptions) {

--- a/src/utils/Reporter.ts
+++ b/src/utils/Reporter.ts
@@ -4,12 +4,24 @@ import {
 } from "@eyevinn/player-analytics-specification";
 import { EPAS_VERSION, HEARTBEAT_INTERVAL } from "./constants";
 
+export type TAnalyticsSendError = {
+  status?: number;
+  statusText?: string;
+  message: string;
+};
+
+export type TOnSendError = (
+  error: TAnalyticsSendError,
+  event: TPlayerAnalyticsEvent
+) => void;
+
 export interface IReporterOptions {
   eventsinkUrl: string;
   heartbeatInterval?: number;
   sessionId?: string;
   shardId?: string;
   debug?: boolean;
+  onError?: TOnSendError;
 }
 
 export interface IReporterPostOptions {
@@ -26,6 +38,7 @@ export class Reporter {
   private shardId?: string;
   private heartbeatInterval?: number;
   private isInitiated = false;
+  private onError?: TOnSendError;
 
   constructor(options: IReporterOptions) {
     this.debug = options.debug ?? false;
@@ -33,6 +46,7 @@ export class Reporter {
     this.eventsinkUrl = options.eventsinkUrl;
     this.sessionId = options.sessionId;
     this.heartbeatInterval = options.heartbeatInterval || HEARTBEAT_INTERVAL;
+    this.onError = options.onError;
 
     if (this.debug) {
       console.log("[AnalyticsReporter] Initiated AnalyticsReporter", options);
@@ -117,10 +131,26 @@ export class Reporter {
         body: JSON.stringify(payload),
       }).then((res) => {
         if (res && !res.ok) {
-          console.warn(`[AnalyticsReporter] Send failed: ${res.status} ${res.statusText}`);
+          const error: TAnalyticsSendError = {
+            status: res.status,
+            statusText: res.statusText,
+            message: `Send failed: ${res.status} ${res.statusText}`,
+          };
+          if (this.onError) {
+            this.onError(error, data);
+          } else {
+            console.warn(`[AnalyticsReporter] ${error.message}`);
+          }
         }
       }).catch((err) => {
-        console.warn('[AnalyticsReporter] Send failed:', err.message);
+        const error: TAnalyticsSendError = {
+          message: err.message,
+        };
+        if (this.onError) {
+          this.onError(error, data);
+        } else {
+          console.warn('[AnalyticsReporter] Send failed:', err.message);
+        }
       });
     }
   }


### PR DESCRIPTION
## Summary
- Add optional `onError` callback to `PlayerAnalyticsConnector` and `PlayerAnalytics` constructors
- When provided, receives structured error info (`status`, `statusText`, `message`) and the failed event
- When not provided, falls back to `console.warn` (backwards compatible)
- Exports `TAnalyticsSendError` and `TOnSendError` types for consumers

Closes #16

## Usage
```typescript
const connector = new PlayerAnalyticsConnector(
  "https://eventsink.example.com",
  false,
  (error, event) => {
    console.error(`Analytics send failed: ${error.message}`, event.event);
  }
);
```

## Test plan
- [x] `npx tsc` compiles cleanly
- [x] 61 test specs passing
- [x] onError invoked on network failure with correct args
- [x] onError invoked on HTTP 404 with correct args
- [x] console.warn still fires when no callback provided
- [x] Callback threads through Connector → Analytics → Reporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)