### PR TITLE
feat: non-blocking init with event queuing

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,3 +7,8 @@ export {
   PlayerAnalyticsConnector,
   IPlayerAnalyticsConnectorInitOptions,
 } from "./src/PlayerAnalyticsConnector";
+
+export type {
+  TAnalyticsSendError,
+  TOnSendError,
+} from "./src/utils/Reporter";

--- a/spec/PlayerAnalytics.spec.ts
+++ b/spec/PlayerAnalytics.spec.ts
@@ -157,7 +157,8 @@ describe("PlayerAnalytics", () => {
       expect(mockFetch).toHaveBeenCalled();
       const body = JSON.parse(mockFetch.calls.argsFor(0)[1].body);
       expect(body.event).toBe("playing");
-      expect(body.sessionId).toBe("test-session");
+      // Reporter uses its authoritative sessionId (from server init response)
+      expect(body.sessionId).toBe("test-session-id");
     });
 
     it("should call reporter.send with correct data for pause()", () => {

--- a/spec/PlayerAnalytics.spec.ts
+++ b/spec/PlayerAnalytics.spec.ts
@@ -1,5 +1,7 @@
-import { PlayerAnalytics, IPlayerAnalyticsInitOptions } from "../src/PlayerAnalytics";
-import { Reporter } from "../src/utils/Reporter";
+import {
+  PlayerAnalytics,
+  IPlayerAnalyticsInitOptions,
+} from "../src/PlayerAnalytics";
 import {
   TPlayingEvent,
   TPausedEvent,
@@ -296,7 +298,10 @@ describe("PlayerAnalytics", () => {
 
   describe("debug mode", () => {
     it("should not call fetch when debug mode is enabled", async () => {
-      const analytics = new PlayerAnalytics("https://example.com/analytics", true);
+      const analytics = new PlayerAnalytics(
+        "https://example.com/analytics",
+        true
+      );
 
       spyOn(console, "log");
 
@@ -307,7 +312,10 @@ describe("PlayerAnalytics", () => {
     });
 
     it("should log events to console in debug mode", async () => {
-      const analytics = new PlayerAnalytics("https://example.com/analytics", true);
+      const analytics = new PlayerAnalytics(
+        "https://example.com/analytics",
+        true
+      );
 
       spyOn(console, "log");
 

--- a/spec/PlayerAnalyticsConnector.spec.ts
+++ b/spec/PlayerAnalyticsConnector.spec.ts
@@ -600,6 +600,36 @@ describe("PlayerAnalyticsConnector", () => {
       internals.stopInterval();
     });
 
+    it("should drop queued events when destroy() is called during init", async () => {
+      // End-to-end: load() during pending init queues a 'loading' event.
+      // destroy() must abort the init and prevent that event from reaching the wire.
+      let resolveInit!: (value: unknown) => void;
+      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      mockFetch.and.returnValue(pendingInit);
+
+      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const initPromise = connector.init({ sessionId: "test-session" });
+
+      mockFetch.calls.reset();
+      connector.load(mockVideoElement);
+      // 'loading' is queued at this point
+
+      // Destroy mid-init
+      connector.destroy();
+
+      resolveInit({
+        ok: true,
+        json: () => Promise.resolve({ sessionId: "test-session" }),
+        statusText: "OK",
+      });
+
+      try { await initPromise; } catch { /* expected */ }
+      await flushMicrotasks();
+
+      // No event should reach the wire after destroy
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
     it("should reset pendingHeartbeatStart on init failure (no stale flag for retry)", async () => {
       // First init: PLAYING fires before init completes (sets pendingHeartbeatStart),
       // then init fails. The flag must be cleared so a retry doesn't fire heartbeats

--- a/spec/PlayerAnalyticsConnector.spec.ts
+++ b/spec/PlayerAnalyticsConnector.spec.ts
@@ -511,32 +511,42 @@ describe("PlayerAnalyticsConnector", () => {
   });
 
   describe("non-blocking init", () => {
+    // Helper: flush promise microtask queue
+    async function flushMicrotasks() {
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+    }
+
+    // Type-safe access to private members for test assertions
+    interface ConnectorInternals {
+      sessionId: string;
+      pendingHeartbeatStart: boolean;
+      heartbeatIntervalTimer: ReturnType<typeof setInterval> | null;
+      startInterval: () => void;
+      stopInterval: () => void;
+    }
+
     it("should allow load() before init resolves (events queued)", async () => {
-      let resolveInit: (value: any) => void;
+      let resolveInit!: (value: unknown) => void;
       const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
       mockFetch.and.returnValue(pendingInit);
 
       const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
       const initPromise = connector.init({ sessionId: "test-session" });
 
-      // load() before init resolves — should NOT throw
       mockFetch.calls.reset();
       connector.load(mockVideoElement);
 
-      // loading event should be queued (not dispatched yet)
       expect(mockFetch).not.toHaveBeenCalled();
 
-      // Resolve init
-      resolveInit!({
+      resolveInit({
         ok: true,
         json: () => Promise.resolve({ sessionId: "test-session" }),
         statusText: "OK",
       });
 
       await initPromise;
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
 
-      // loading event should now be flushed
       expect(mockFetch).toHaveBeenCalled();
       const body = JSON.parse(mockFetch.calls.argsFor(0)[1].body);
       expect(body.event).toBe("loading");
@@ -552,12 +562,14 @@ describe("PlayerAnalyticsConnector", () => {
       }));
 
       await connector.init({ sessionId: "client-id" });
+      await flushMicrotasks();
 
-      expect((connector as any).sessionId).toBe("server-generated-id");
+      const internals = connector as unknown as ConnectorInternals;
+      expect(internals.sessionId).toBe("server-generated-id");
     });
 
     it("should defer heartbeat start if PLAYING fires before init resolves", async () => {
-      let resolveInit: (value: any) => void;
+      let resolveInit!: (value: unknown) => void;
       const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
       mockFetch.and.returnValue(pendingInit);
 
@@ -567,29 +579,25 @@ describe("PlayerAnalyticsConnector", () => {
         heartbeatInterval: 5000,
       });
 
-      // Manually trigger startInterval (simulating PLAYING event)
-      (connector as any).startInterval();
+      const internals = connector as unknown as ConnectorInternals;
+      internals.startInterval();
 
-      // Should be pending, not started (no heartbeatInterval yet)
-      expect((connector as any).pendingHeartbeatStart).toBe(true);
-      expect((connector as any).heartbeatIntervalTimer).toBeUndefined();
+      expect(internals.pendingHeartbeatStart).toBe(true);
+      expect(internals.heartbeatIntervalTimer).toBeUndefined();
 
-      // Resolve init
-      resolveInit!({
+      resolveInit({
         ok: true,
         json: () => Promise.resolve({ sessionId: "test-session" }),
         statusText: "OK",
       });
 
       await initPromise;
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
 
-      // Heartbeat should now be started
-      expect((connector as any).pendingHeartbeatStart).toBe(false);
-      expect((connector as any).heartbeatIntervalTimer).toBeDefined();
+      expect(internals.pendingHeartbeatStart).toBe(false);
+      expect(internals.heartbeatIntervalTimer).toBeDefined();
 
-      // Cleanup
-      (connector as any).stopInterval();
+      internals.stopInterval();
     });
   });
 });

--- a/spec/PlayerAnalyticsConnector.spec.ts
+++ b/spec/PlayerAnalyticsConnector.spec.ts
@@ -1,4 +1,7 @@
-import { PlayerAnalyticsConnector, IPlayerAnalyticsConnectorInitOptions } from "../src/PlayerAnalyticsConnector";
+import {
+  PlayerAnalyticsConnector,
+  IPlayerAnalyticsConnectorInitOptions,
+} from "../src/PlayerAnalyticsConnector";
 
 describe("PlayerAnalyticsConnector", () => {
   let mockFetch: jasmine.Spy;
@@ -32,7 +35,9 @@ describe("PlayerAnalyticsConnector", () => {
 
   describe("init()", () => {
     it("should initialize analytics reporter and set analyticsInitiated to true", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
 
       const options: IPlayerAnalyticsConnectorInitOptions = {
         sessionId: "session-123",
@@ -46,7 +51,9 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should store heartbeatInterval from init response", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
 
       await connector.init({ heartbeatInterval: 45000 });
 
@@ -56,7 +63,9 @@ describe("PlayerAnalyticsConnector", () => {
 
   describe("load()", () => {
     it("should set player reference and send loading event", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       await connector.init({ sessionId: "test-session" });
 
       mockFetch.calls.reset();
@@ -71,7 +80,9 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should initiate video event filter", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       await connector.init({ sessionId: "test-session" });
 
       connector.load(mockVideoElement);
@@ -82,7 +93,9 @@ describe("PlayerAnalyticsConnector", () => {
 
   describe("playbackState()", () => {
     it("should return playhead 0 when currentTime is 0", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       await connector.init({ sessionId: "test-session" });
 
       mockVideoElement.currentTime = 0;
@@ -99,7 +112,9 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should return duration -1 for live stream (Infinity duration)", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       await connector.init({ sessionId: "test-session" });
 
       mockVideoElement.currentTime = 10;
@@ -116,7 +131,9 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should return playhead -1 when duration is -1", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       await connector.init({ sessionId: "test-session" });
 
       mockVideoElement.currentTime = 10;
@@ -133,7 +150,9 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should return correct playhead for normal playback", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       await connector.init({ sessionId: "test-session" });
 
       mockVideoElement.currentTime = 42.5;
@@ -160,8 +179,13 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should start heartbeat interval when startInterval is called", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
-      await connector.init({ sessionId: "test-session", heartbeatInterval: 10000 });
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
+      await connector.init({
+        sessionId: "test-session",
+        heartbeatInterval: 10000,
+      });
 
       connector.load(mockVideoElement);
 
@@ -178,8 +202,13 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should not start duplicate interval if already running", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
-      await connector.init({ sessionId: "test-session", heartbeatInterval: 10000 });
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
+      await connector.init({
+        sessionId: "test-session",
+        heartbeatInterval: 10000,
+      });
 
       connector.load(mockVideoElement);
 
@@ -194,8 +223,13 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should stop heartbeat interval when stopInterval is called", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
-      await connector.init({ sessionId: "test-session", heartbeatInterval: 10000 });
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
+      await connector.init({
+        sessionId: "test-session",
+        heartbeatInterval: 10000,
+      });
 
       connector.load(mockVideoElement);
 
@@ -209,8 +243,13 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should restart heartbeat after stop", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
-      await connector.init({ sessionId: "test-session", heartbeatInterval: 5000 });
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
+      await connector.init({
+        sessionId: "test-session",
+        heartbeatInterval: 5000,
+      });
 
       connector.load(mockVideoElement);
 
@@ -231,7 +270,9 @@ describe("PlayerAnalyticsConnector", () => {
 
   describe("report methods when not initialized", () => {
     it("should warn when reportBitrateChange is called before init", () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       spyOn(console, "warn");
 
       connector.reportBitrateChange({ bitrate: 5000000 });
@@ -243,7 +284,9 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should warn when reportMetadata is called before init", () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       spyOn(console, "warn");
 
       connector.reportMetadata({ contentId: "test", live: false });
@@ -254,7 +297,9 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should warn when reportError is called before init", () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       spyOn(console, "warn");
 
       connector.reportError({
@@ -269,7 +314,9 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should warn when reportStop is called before init", () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       spyOn(console, "warn");
 
       connector.reportStop();
@@ -280,7 +327,9 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should warn when reportWarning is called before init", () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       spyOn(console, "warn");
 
       connector.reportWarning({
@@ -306,7 +355,11 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should send bitrate_changed event with correct payload", () => {
-      connector.reportBitrateChange({ bitrate: 5000000, width: 1920, height: 1080 });
+      connector.reportBitrateChange({
+        bitrate: 5000000,
+        width: 1920,
+        height: 1080,
+      });
 
       expect(mockFetch).toHaveBeenCalled();
       const body = JSON.parse(mockFetch.calls.argsFor(0)[1].body);
@@ -400,7 +453,9 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should set analyticsInitiated to false", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       await connector.init({ sessionId: "test-session" });
 
       connector.deinit();
@@ -409,8 +464,13 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should stop heartbeat interval", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
-      await connector.init({ sessionId: "test-session", heartbeatInterval: 5000 });
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
+      await connector.init({
+        sessionId: "test-session",
+        heartbeatInterval: 5000,
+      });
 
       connector.load(mockVideoElement);
       (connector as any).startInterval();
@@ -424,7 +484,9 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should teardown video event filter", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       await connector.init({ sessionId: "test-session" });
 
       connector.load(mockVideoElement);
@@ -439,7 +501,9 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should warn when called before init", () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       spyOn(console, "warn");
 
       connector.deinit();
@@ -460,7 +524,9 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should set analyticsInitiated to false", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       await connector.init({ sessionId: "test-session" });
 
       connector.destroy();
@@ -469,8 +535,13 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should stop heartbeat and teardown filter", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
-      await connector.init({ sessionId: "test-session", heartbeatInterval: 5000 });
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
+      await connector.init({
+        sessionId: "test-session",
+        heartbeatInterval: 5000,
+      });
 
       connector.load(mockVideoElement);
       (connector as any).startInterval();
@@ -488,7 +559,9 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should destroy playerAnalytics instance", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       await connector.init({ sessionId: "test-session" });
 
       spyOn((connector as any).playerAnalytics, "destroy");
@@ -499,7 +572,9 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should warn when called before init", () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       spyOn(console, "warn");
 
       connector.destroy();
@@ -527,10 +602,14 @@ describe("PlayerAnalyticsConnector", () => {
 
     it("should allow load() before init resolves (events queued)", async () => {
       let resolveInit!: (value: unknown) => void;
-      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      const pendingInit = new Promise((resolve) => {
+        resolveInit = resolve;
+      });
       mockFetch.and.returnValue(pendingInit);
 
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       const initPromise = connector.init({ sessionId: "test-session" });
 
       mockFetch.calls.reset();
@@ -553,13 +632,17 @@ describe("PlayerAnalyticsConnector", () => {
     });
 
     it("should update sessionId from server response", async () => {
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
 
-      mockFetch.and.returnValue(Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ sessionId: "server-generated-id" }),
-        statusText: "OK",
-      }));
+      mockFetch.and.returnValue(
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ sessionId: "server-generated-id" }),
+          statusText: "OK",
+        })
+      );
 
       await connector.init({ sessionId: "client-id" });
       await flushMicrotasks();
@@ -570,10 +653,14 @@ describe("PlayerAnalyticsConnector", () => {
 
     it("should defer heartbeat start if PLAYING fires before init resolves", async () => {
       let resolveInit!: (value: unknown) => void;
-      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      const pendingInit = new Promise((resolve) => {
+        resolveInit = resolve;
+      });
       mockFetch.and.returnValue(pendingInit);
 
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       const initPromise = connector.init({
         sessionId: "test-session",
         heartbeatInterval: 5000,
@@ -604,10 +691,14 @@ describe("PlayerAnalyticsConnector", () => {
       // Same as the destroy() case but for deinit() — must also cascade
       // to reporter.destroy() to abort the in-flight init.
       let resolveInit!: (value: unknown) => void;
-      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      const pendingInit = new Promise((resolve) => {
+        resolveInit = resolve;
+      });
       mockFetch.and.returnValue(pendingInit);
 
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       const initPromise = connector.init({ sessionId: "test-session" });
 
       mockFetch.calls.reset();
@@ -623,7 +714,11 @@ describe("PlayerAnalyticsConnector", () => {
         statusText: "OK",
       });
 
-      try { await initPromise; } catch { /* expected */ }
+      try {
+        await initPromise;
+      } catch {
+        /* expected */
+      }
       await flushMicrotasks();
 
       // No event should reach the wire after deinit
@@ -634,10 +729,14 @@ describe("PlayerAnalyticsConnector", () => {
       // End-to-end: load() during pending init queues a 'loading' event.
       // destroy() must abort the init and prevent that event from reaching the wire.
       let resolveInit!: (value: unknown) => void;
-      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      const pendingInit = new Promise((resolve) => {
+        resolveInit = resolve;
+      });
       mockFetch.and.returnValue(pendingInit);
 
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       const initPromise = connector.init({ sessionId: "test-session" });
 
       mockFetch.calls.reset();
@@ -653,7 +752,11 @@ describe("PlayerAnalyticsConnector", () => {
         statusText: "OK",
       });
 
-      try { await initPromise; } catch { /* expected */ }
+      try {
+        await initPromise;
+      } catch {
+        /* expected */
+      }
       await flushMicrotasks();
 
       // No event should reach the wire after destroy
@@ -664,12 +767,16 @@ describe("PlayerAnalyticsConnector", () => {
       // First init: PLAYING fires before init completes (sets pendingHeartbeatStart),
       // then init fails. The flag must be cleared so a retry doesn't fire heartbeats
       // without a new PLAYING event.
-      mockFetch.and.returnValue(Promise.resolve({
-        ok: false,
-        statusText: "Service Unavailable",
-      }));
+      mockFetch.and.returnValue(
+        Promise.resolve({
+          ok: false,
+          statusText: "Service Unavailable",
+        })
+      );
 
-      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const connector = new PlayerAnalyticsConnector(
+        "https://example.com/analytics"
+      );
       const initPromise = connector.init({
         sessionId: "test-session",
         heartbeatInterval: 5000,
@@ -680,7 +787,11 @@ describe("PlayerAnalyticsConnector", () => {
       internals.startInterval();
       expect(internals.pendingHeartbeatStart).toBe(true);
 
-      try { await initPromise; } catch { /* expected */ }
+      try {
+        await initPromise;
+      } catch {
+        /* expected */
+      }
       await flushMicrotasks();
 
       // pendingHeartbeatStart must be cleared after init failure

--- a/spec/PlayerAnalyticsConnector.spec.ts
+++ b/spec/PlayerAnalyticsConnector.spec.ts
@@ -509,4 +509,87 @@ describe("PlayerAnalyticsConnector", () => {
       );
     });
   });
+
+  describe("non-blocking init", () => {
+    it("should allow load() before init resolves (events queued)", async () => {
+      let resolveInit: (value: any) => void;
+      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      mockFetch.and.returnValue(pendingInit);
+
+      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const initPromise = connector.init({ sessionId: "test-session" });
+
+      // load() before init resolves — should NOT throw
+      mockFetch.calls.reset();
+      connector.load(mockVideoElement);
+
+      // loading event should be queued (not dispatched yet)
+      expect(mockFetch).not.toHaveBeenCalled();
+
+      // Resolve init
+      resolveInit!({
+        ok: true,
+        json: () => Promise.resolve({ sessionId: "test-session" }),
+        statusText: "OK",
+      });
+
+      await initPromise;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // loading event should now be flushed
+      expect(mockFetch).toHaveBeenCalled();
+      const body = JSON.parse(mockFetch.calls.argsFor(0)[1].body);
+      expect(body.event).toBe("loading");
+    });
+
+    it("should update sessionId from server response", async () => {
+      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+
+      mockFetch.and.returnValue(Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ sessionId: "server-generated-id" }),
+        statusText: "OK",
+      }));
+
+      await connector.init({ sessionId: "client-id" });
+
+      expect((connector as any).sessionId).toBe("server-generated-id");
+    });
+
+    it("should defer heartbeat start if PLAYING fires before init resolves", async () => {
+      let resolveInit: (value: any) => void;
+      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      mockFetch.and.returnValue(pendingInit);
+
+      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const initPromise = connector.init({
+        sessionId: "test-session",
+        heartbeatInterval: 5000,
+      });
+
+      // Manually trigger startInterval (simulating PLAYING event)
+      (connector as any).startInterval();
+
+      // Should be pending, not started (no heartbeatInterval yet)
+      expect((connector as any).pendingHeartbeatStart).toBe(true);
+      expect((connector as any).heartbeatIntervalTimer).toBeUndefined();
+
+      // Resolve init
+      resolveInit!({
+        ok: true,
+        json: () => Promise.resolve({ sessionId: "test-session" }),
+        statusText: "OK",
+      });
+
+      await initPromise;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Heartbeat should now be started
+      expect((connector as any).pendingHeartbeatStart).toBe(false);
+      expect((connector as any).heartbeatIntervalTimer).toBeDefined();
+
+      // Cleanup
+      (connector as any).stopInterval();
+    });
+  });
 });

--- a/spec/PlayerAnalyticsConnector.spec.ts
+++ b/spec/PlayerAnalyticsConnector.spec.ts
@@ -600,6 +600,36 @@ describe("PlayerAnalyticsConnector", () => {
       internals.stopInterval();
     });
 
+    it("should drop queued events when deinit() is called during init", async () => {
+      // Same as the destroy() case but for deinit() — must also cascade
+      // to reporter.destroy() to abort the in-flight init.
+      let resolveInit!: (value: unknown) => void;
+      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      mockFetch.and.returnValue(pendingInit);
+
+      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const initPromise = connector.init({ sessionId: "test-session" });
+
+      mockFetch.calls.reset();
+      connector.load(mockVideoElement);
+      // 'loading' is queued at this point
+
+      // Deinit mid-init (instead of destroy)
+      connector.deinit();
+
+      resolveInit({
+        ok: true,
+        json: () => Promise.resolve({ sessionId: "test-session" }),
+        statusText: "OK",
+      });
+
+      try { await initPromise; } catch { /* expected */ }
+      await flushMicrotasks();
+
+      // No event should reach the wire after deinit
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
     it("should drop queued events when destroy() is called during init", async () => {
       // End-to-end: load() during pending init queues a 'loading' event.
       // destroy() must abort the init and prevent that event from reaching the wire.

--- a/spec/PlayerAnalyticsConnector.spec.ts
+++ b/spec/PlayerAnalyticsConnector.spec.ts
@@ -599,5 +599,32 @@ describe("PlayerAnalyticsConnector", () => {
 
       internals.stopInterval();
     });
+
+    it("should reset pendingHeartbeatStart on init failure (no stale flag for retry)", async () => {
+      // First init: PLAYING fires before init completes (sets pendingHeartbeatStart),
+      // then init fails. The flag must be cleared so a retry doesn't fire heartbeats
+      // without a new PLAYING event.
+      mockFetch.and.returnValue(Promise.resolve({
+        ok: false,
+        statusText: "Service Unavailable",
+      }));
+
+      const connector = new PlayerAnalyticsConnector("https://example.com/analytics");
+      const initPromise = connector.init({
+        sessionId: "test-session",
+        heartbeatInterval: 5000,
+      });
+
+      const internals = connector as unknown as ConnectorInternals;
+      // Simulate PLAYING event during init
+      internals.startInterval();
+      expect(internals.pendingHeartbeatStart).toBe(true);
+
+      try { await initPromise; } catch { /* expected */ }
+      await flushMicrotasks();
+
+      // pendingHeartbeatStart must be cleared after init failure
+      expect(internals.pendingHeartbeatStart).toBe(false);
+    });
   });
 });

--- a/spec/Reporter.spec.ts
+++ b/spec/Reporter.spec.ts
@@ -39,7 +39,9 @@ describe("Reporter", () => {
       const [url, fetchOptions] = mockFetch.calls.argsFor(0);
       expect(url).toBe("https://example.com/analytics");
       expect(fetchOptions.method).toBe("POST");
-      expect(fetchOptions.headers["Content-Type"]).toBe("application/json; charset=utf-8");
+      expect(fetchOptions.headers["Content-Type"]).toBe(
+        "application/json; charset=utf-8"
+      );
       expect(fetchOptions.headers["X-EPAS-Event"]).toBe("init");
       expect(fetchOptions.headers["X-EPAS-Version"]).toBeDefined();
     });
@@ -269,7 +271,8 @@ describe("Reporter", () => {
 
       expect(mockFetch).toHaveBeenCalled();
       expect(console.warn).toHaveBeenCalledWith(
-        "[AnalyticsReporter] Send failed:", "Network failure"
+        "[AnalyticsReporter] Send failed:",
+        "Network failure"
       );
     });
 
@@ -284,11 +287,13 @@ describe("Reporter", () => {
 
       (reporter as any).debug = false;
       mockFetch.calls.reset();
-      mockFetch.and.returnValue(Promise.resolve({
-        ok: false,
-        status: 404,
-        statusText: "Not Found",
-      }));
+      mockFetch.and.returnValue(
+        Promise.resolve({
+          ok: false,
+          status: 404,
+          statusText: "Not Found",
+        })
+      );
 
       spyOn(console, "warn");
 
@@ -343,7 +348,9 @@ describe("Reporter", () => {
 
     it("should queue events sent while init is in flight", async () => {
       let resolveInit!: (value: unknown) => void;
-      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      const pendingInit = new Promise((resolve) => {
+        resolveInit = resolve;
+      });
       mockFetch.and.returnValue(pendingInit);
 
       const reporter = new Reporter({
@@ -392,7 +399,9 @@ describe("Reporter", () => {
 
     it("should patch queued events with server sessionId on flush", async () => {
       let resolveInit!: (value: unknown) => void;
-      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      const pendingInit = new Promise((resolve) => {
+        resolveInit = resolve;
+      });
       mockFetch.and.returnValue(pendingInit);
 
       const reporter = new Reporter({
@@ -424,10 +433,12 @@ describe("Reporter", () => {
     });
 
     it("should discard queued events if init fails", async () => {
-      mockFetch.and.returnValue(Promise.resolve({
-        ok: false,
-        statusText: "Internal Server Error",
-      }));
+      mockFetch.and.returnValue(
+        Promise.resolve({
+          ok: false,
+          statusText: "Internal Server Error",
+        })
+      );
 
       const reporter = new Reporter({
         eventsinkUrl: "https://example.com/analytics",
@@ -482,7 +493,9 @@ describe("Reporter", () => {
       // This test verifies the ordering barrier: events sent during the flush
       // window must not overtake the queued chain on the wire.
       let resolveInit!: (value: unknown) => void;
-      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      const pendingInit = new Promise((resolve) => {
+        resolveInit = resolve;
+      });
       mockFetch.and.returnValue(pendingInit);
 
       const reporter = new Reporter({
@@ -494,8 +507,20 @@ describe("Reporter", () => {
       mockFetch.calls.reset();
 
       // Queue 2 events during init
-      reporter.send({ event: "loading", sessionId: "test-session-id", timestamp: 1, playhead: 0, duration: 0 } as TPlayerAnalyticsEvent);
-      reporter.send({ event: "loaded", sessionId: "test-session-id", timestamp: 2, playhead: 0, duration: 0 } as TPlayerAnalyticsEvent);
+      reporter.send({
+        event: "loading",
+        sessionId: "test-session-id",
+        timestamp: 1,
+        playhead: 0,
+        duration: 0,
+      } as TPlayerAnalyticsEvent);
+      reporter.send({
+        event: "loaded",
+        sessionId: "test-session-id",
+        timestamp: 2,
+        playhead: 0,
+        duration: 0,
+      } as TPlayerAnalyticsEvent);
 
       expect(mockFetch).not.toHaveBeenCalled();
 
@@ -504,9 +529,17 @@ describe("Reporter", () => {
       mockFetch.and.callFake(() => {
         dispatchCallCount++;
         // Slow down the first dispatch — gives us a window to send a new event mid-flush
-        return new Promise((resolve) => setTimeout(() => resolve({
-          ok: true, status: 200, statusText: "OK",
-        }), dispatchCallCount === 1 ? 30 : 0));
+        return new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                status: 200,
+                statusText: "OK",
+              }),
+            dispatchCallCount === 1 ? 30 : 0
+          )
+        );
       });
 
       resolveInit({
@@ -519,7 +552,13 @@ describe("Reporter", () => {
       await new Promise((resolve) => setTimeout(resolve, 5));
 
       // Send a third event while flush is still in progress — must NOT overtake queue
-      reporter.send({ event: "playing", sessionId: "test-session-id", timestamp: 3, playhead: 0, duration: 0 } as TPlayerAnalyticsEvent);
+      reporter.send({
+        event: "playing",
+        sessionId: "test-session-id",
+        timestamp: 3,
+        playhead: 0,
+        duration: 0,
+      } as TPlayerAnalyticsEvent);
 
       await initPromise;
       // Allow all serialized awaits to settle
@@ -527,7 +566,9 @@ describe("Reporter", () => {
 
       // All 3 events should have been sent in order: loading, loaded, playing
       expect(mockFetch.calls.count()).toBe(3);
-      const events = mockFetch.calls.allArgs().map(args => JSON.parse(args[1].body).event);
+      const events = mockFetch.calls
+        .allArgs()
+        .map((args) => JSON.parse(args[1].body).event);
       expect(events).toEqual(["loading", "loaded", "playing"]);
     });
   });
@@ -539,7 +580,9 @@ describe("Reporter", () => {
 
     it("should drop queued events when destroy() is called during init", async () => {
       let resolveInit!: (value: unknown) => void;
-      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      const pendingInit = new Promise((resolve) => {
+        resolveInit = resolve;
+      });
       mockFetch.and.returnValue(pendingInit);
 
       const reporter = new Reporter({
@@ -551,8 +594,20 @@ describe("Reporter", () => {
       mockFetch.calls.reset();
 
       // Queue events during init
-      reporter.send({ event: "loading", sessionId: "test-session-id", timestamp: 1, playhead: 0, duration: 0 } as TPlayerAnalyticsEvent);
-      reporter.send({ event: "playing", sessionId: "test-session-id", timestamp: 2, playhead: 0, duration: 0 } as TPlayerAnalyticsEvent);
+      reporter.send({
+        event: "loading",
+        sessionId: "test-session-id",
+        timestamp: 1,
+        playhead: 0,
+        duration: 0,
+      } as TPlayerAnalyticsEvent);
+      reporter.send({
+        event: "playing",
+        sessionId: "test-session-id",
+        timestamp: 2,
+        playhead: 0,
+        duration: 0,
+      } as TPlayerAnalyticsEvent);
 
       // Destroy BEFORE init resolves
       reporter.destroy();
@@ -564,7 +619,11 @@ describe("Reporter", () => {
         statusText: "OK",
       });
 
-      try { await initPromise; } catch { /* expected to reject */ }
+      try {
+        await initPromise;
+      } catch {
+        /* expected to reject */
+      }
       await flushMicrotasks();
 
       // No events should have been dispatched
@@ -584,7 +643,13 @@ describe("Reporter", () => {
       reporter.destroy();
       spyOn(console, "warn");
 
-      reporter.send({ event: "playing", sessionId: "test-session-id", timestamp: 1, playhead: 0, duration: 0 } as TPlayerAnalyticsEvent);
+      reporter.send({
+        event: "playing",
+        sessionId: "test-session-id",
+        timestamp: 1,
+        playhead: 0,
+        duration: 0,
+      } as TPlayerAnalyticsEvent);
 
       expect(mockFetch).not.toHaveBeenCalled();
       // Don't warn — it's expected after destroy

--- a/spec/Reporter.spec.ts
+++ b/spec/Reporter.spec.ts
@@ -477,5 +477,58 @@ describe("Reporter", () => {
 
       expect(result1.sessionId).toBe(result2.sessionId);
     });
+
+    it("should preserve event order even when send() is called between flush completion and state=ready", async () => {
+      // This test verifies the ordering barrier: events sent during the flush
+      // window must not overtake the queued chain on the wire.
+      let resolveInit!: (value: unknown) => void;
+      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      mockFetch.and.returnValue(pendingInit);
+
+      const reporter = new Reporter({
+        eventsinkUrl: "https://example.com/analytics",
+        sessionId: "test-session-id",
+      });
+
+      const initPromise = reporter.init();
+      mockFetch.calls.reset();
+
+      // Queue 2 events during init
+      reporter.send({ event: "loading", sessionId: "test-session-id", timestamp: 1, playhead: 0, duration: 0 } as TPlayerAnalyticsEvent);
+      reporter.send({ event: "loaded", sessionId: "test-session-id", timestamp: 2, playhead: 0, duration: 0 } as TPlayerAnalyticsEvent);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+
+      // Resolve init — flush starts. Make dispatch slow so we have time to call send during flush.
+      let dispatchCallCount = 0;
+      mockFetch.and.callFake(() => {
+        dispatchCallCount++;
+        // Slow down the first dispatch — gives us a window to send a new event mid-flush
+        return new Promise((resolve) => setTimeout(() => resolve({
+          ok: true, status: 200, statusText: "OK",
+        }), dispatchCallCount === 1 ? 30 : 0));
+      });
+
+      resolveInit({
+        ok: true,
+        json: () => Promise.resolve({ sessionId: "server-session-id" }),
+        statusText: "OK",
+      });
+
+      // Wait briefly so flush starts dispatching the first queued event
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      // Send a third event while flush is still in progress — must NOT overtake queue
+      reporter.send({ event: "playing", sessionId: "test-session-id", timestamp: 3, playhead: 0, duration: 0 } as TPlayerAnalyticsEvent);
+
+      await initPromise;
+      // Allow all serialized awaits to settle
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // All 3 events should have been sent in order: loading, loaded, playing
+      expect(mockFetch.calls.count()).toBe(3);
+      const events = mockFetch.calls.allArgs().map(args => JSON.parse(args[1].body).event);
+      expect(events).toEqual(["loading", "loaded", "playing"]);
+    });
   });
 });

--- a/spec/Reporter.spec.ts
+++ b/spec/Reporter.spec.ts
@@ -180,7 +180,8 @@ describe("Reporter", () => {
 
       const body = JSON.parse(fetchOptions.body);
       expect(body.event).toBe("playing");
-      expect(body.sessionId).toBe("test-session-id");
+      // Reporter uses its authoritative sessionId (from server init response)
+      expect(body.sessionId).toBe("server-generated-id");
       expect(body.playhead).toBe(10.5);
     });
 
@@ -331,6 +332,162 @@ describe("Reporter", () => {
         eventData
       );
       expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("event queuing during init", () => {
+    it("should queue events sent while init is in flight", async () => {
+      let resolveInit: (value: any) => void;
+      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      mockFetch.and.returnValue(pendingInit);
+
+      const options: IReporterOptions = {
+        eventsinkUrl: "https://example.com/analytics",
+        sessionId: "test-session-id",
+      };
+      const reporter = new Reporter(options);
+
+      // Start init but don't resolve yet
+      const initPromise = reporter.init();
+      mockFetch.calls.reset();
+
+      // Send events while init is in flight
+      const event1: TPlayerAnalyticsEvent = {
+        event: "playing",
+        sessionId: "test-session-id",
+        timestamp: 1000,
+        playhead: 0,
+        duration: 120,
+      };
+      const event2: TPlayerAnalyticsEvent = {
+        event: "heartbeat",
+        sessionId: "test-session-id",
+        timestamp: 2000,
+        playhead: 10,
+        duration: 120,
+      };
+
+      reporter.send(event1);
+      reporter.send(event2);
+
+      // Events should be queued, not dispatched
+      expect(mockFetch).not.toHaveBeenCalled();
+
+      // Now resolve init
+      resolveInit!({
+        ok: true,
+        json: () => Promise.resolve({ sessionId: "server-session-id" }),
+        statusText: "OK",
+      });
+
+      await initPromise;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Both events should now have been flushed
+      expect(mockFetch.calls.count()).toBe(2);
+
+      // Verify events flushed in order
+      const body1 = JSON.parse(mockFetch.calls.argsFor(0)[1].body);
+      expect(body1.event).toBe("playing");
+      const body2 = JSON.parse(mockFetch.calls.argsFor(1)[1].body);
+      expect(body2.event).toBe("heartbeat");
+    });
+
+    it("should patch queued events with server sessionId on flush", async () => {
+      let resolveInit: (value: any) => void;
+      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      mockFetch.and.returnValue(pendingInit);
+
+      const options: IReporterOptions = {
+        eventsinkUrl: "https://example.com/analytics",
+        // No client sessionId provided
+      };
+      const reporter = new Reporter(options);
+      const initPromise = reporter.init();
+      mockFetch.calls.reset();
+
+      reporter.send({
+        event: "loading",
+        sessionId: undefined,
+        timestamp: 1000,
+        playhead: -1,
+        duration: -1,
+      } as TPlayerAnalyticsEvent);
+
+      // Resolve init with server-generated sessionId
+      resolveInit!({
+        ok: true,
+        json: () => Promise.resolve({ sessionId: "server-generated-id" }),
+        statusText: "OK",
+      });
+
+      await initPromise;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockFetch.calls.count()).toBe(1);
+      const body = JSON.parse(mockFetch.calls.argsFor(0)[1].body);
+      expect(body.sessionId).toBe("server-generated-id");
+    });
+
+    it("should discard queued events if init fails", async () => {
+      mockFetch.and.returnValue(Promise.resolve({
+        ok: false,
+        statusText: "Internal Server Error",
+      }));
+
+      const options: IReporterOptions = {
+        eventsinkUrl: "https://example.com/analytics",
+        sessionId: "test-session-id",
+      };
+      const reporter = new Reporter(options);
+
+      // Start init (will fail) — queue an event during the microtask gap
+      const initPromise = reporter.init();
+
+      // Manually set state to test the failed path
+      reporter.send({
+        event: "playing",
+        sessionId: "test-session-id",
+        timestamp: 1000,
+        playhead: 0,
+        duration: 120,
+      } as TPlayerAnalyticsEvent);
+
+      try {
+        await initPromise;
+      } catch (e) {
+        // Expected
+      }
+
+      // After failure, send should warn
+      mockFetch.calls.reset();
+      spyOn(console, "warn");
+
+      reporter.send({
+        event: "heartbeat",
+        sessionId: "test-session-id",
+        timestamp: 2000,
+        playhead: 10,
+        duration: 120,
+      } as TPlayerAnalyticsEvent);
+
+      expect(console.warn).toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("should not allow double init", async () => {
+      const options: IReporterOptions = {
+        eventsinkUrl: "https://example.com/analytics",
+        sessionId: "test-session-id",
+        debug: true,
+      };
+      const reporter = new Reporter(options);
+
+      const result1 = await reporter.init();
+      const result2 = await reporter.init();
+
+      // Second call should return same promise/result
+      expect(result1.sessionId).toBe(result2.sessionId);
     });
   });
 });

--- a/spec/Reporter.spec.ts
+++ b/spec/Reporter.spec.ts
@@ -531,4 +531,64 @@ describe("Reporter", () => {
       expect(events).toEqual(["loading", "loaded", "playing"]);
     });
   });
+
+  describe("destroy()", () => {
+    async function flushMicrotasks() {
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+    }
+
+    it("should drop queued events when destroy() is called during init", async () => {
+      let resolveInit!: (value: unknown) => void;
+      const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
+      mockFetch.and.returnValue(pendingInit);
+
+      const reporter = new Reporter({
+        eventsinkUrl: "https://example.com/analytics",
+        sessionId: "test-session-id",
+      });
+
+      const initPromise = reporter.init();
+      mockFetch.calls.reset();
+
+      // Queue events during init
+      reporter.send({ event: "loading", sessionId: "test-session-id", timestamp: 1, playhead: 0, duration: 0 } as TPlayerAnalyticsEvent);
+      reporter.send({ event: "playing", sessionId: "test-session-id", timestamp: 2, playhead: 0, duration: 0 } as TPlayerAnalyticsEvent);
+
+      // Destroy BEFORE init resolves
+      reporter.destroy();
+
+      // Now resolve the init fetch — but reporter should abort, not flush
+      resolveInit({
+        ok: true,
+        json: () => Promise.resolve({ sessionId: "server-session-id" }),
+        statusText: "OK",
+      });
+
+      try { await initPromise; } catch { /* expected to reject */ }
+      await flushMicrotasks();
+
+      // No events should have been dispatched
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("should silently drop send() calls after destroy()", async () => {
+      const reporter = new Reporter({
+        eventsinkUrl: "https://example.com/analytics",
+        sessionId: "test-session-id",
+        debug: true,
+      });
+
+      await reporter.init();
+      mockFetch.calls.reset();
+
+      reporter.destroy();
+      spyOn(console, "warn");
+
+      reporter.send({ event: "playing", sessionId: "test-session-id", timestamp: 1, playhead: 0, duration: 0 } as TPlayerAnalyticsEvent);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      // Don't warn — it's expected after destroy
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/spec/Reporter.spec.ts
+++ b/spec/Reporter.spec.ts
@@ -336,22 +336,24 @@ describe("Reporter", () => {
   });
 
   describe("event queuing during init", () => {
+    // Helper: flush promise microtask queue
+    async function flushMicrotasks() {
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+    }
+
     it("should queue events sent while init is in flight", async () => {
-      let resolveInit: (value: any) => void;
+      let resolveInit!: (value: unknown) => void;
       const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
       mockFetch.and.returnValue(pendingInit);
 
-      const options: IReporterOptions = {
+      const reporter = new Reporter({
         eventsinkUrl: "https://example.com/analytics",
         sessionId: "test-session-id",
-      };
-      const reporter = new Reporter(options);
+      });
 
-      // Start init but don't resolve yet
       const initPromise = reporter.init();
       mockFetch.calls.reset();
 
-      // Send events while init is in flight
       const event1: TPlayerAnalyticsEvent = {
         event: "playing",
         sessionId: "test-session-id",
@@ -370,23 +372,18 @@ describe("Reporter", () => {
       reporter.send(event1);
       reporter.send(event2);
 
-      // Events should be queued, not dispatched
       expect(mockFetch).not.toHaveBeenCalled();
 
-      // Now resolve init
-      resolveInit!({
+      resolveInit({
         ok: true,
         json: () => Promise.resolve({ sessionId: "server-session-id" }),
         statusText: "OK",
       });
 
       await initPromise;
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
 
-      // Both events should now have been flushed
       expect(mockFetch.calls.count()).toBe(2);
-
-      // Verify events flushed in order
       const body1 = JSON.parse(mockFetch.calls.argsFor(0)[1].body);
       expect(body1.event).toBe("playing");
       const body2 = JSON.parse(mockFetch.calls.argsFor(1)[1].body);
@@ -394,15 +391,13 @@ describe("Reporter", () => {
     });
 
     it("should patch queued events with server sessionId on flush", async () => {
-      let resolveInit: (value: any) => void;
+      let resolveInit!: (value: unknown) => void;
       const pendingInit = new Promise((resolve) => { resolveInit = resolve; });
       mockFetch.and.returnValue(pendingInit);
 
-      const options: IReporterOptions = {
+      const reporter = new Reporter({
         eventsinkUrl: "https://example.com/analytics",
-        // No client sessionId provided
-      };
-      const reporter = new Reporter(options);
+      });
       const initPromise = reporter.init();
       mockFetch.calls.reset();
 
@@ -414,15 +409,14 @@ describe("Reporter", () => {
         duration: -1,
       } as TPlayerAnalyticsEvent);
 
-      // Resolve init with server-generated sessionId
-      resolveInit!({
+      resolveInit({
         ok: true,
         json: () => Promise.resolve({ sessionId: "server-generated-id" }),
         statusText: "OK",
       });
 
       await initPromise;
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
 
       expect(mockFetch.calls.count()).toBe(1);
       const body = JSON.parse(mockFetch.calls.argsFor(0)[1].body);
@@ -435,16 +429,13 @@ describe("Reporter", () => {
         statusText: "Internal Server Error",
       }));
 
-      const options: IReporterOptions = {
+      const reporter = new Reporter({
         eventsinkUrl: "https://example.com/analytics",
         sessionId: "test-session-id",
-      };
-      const reporter = new Reporter(options);
+      });
 
-      // Start init (will fail) — queue an event during the microtask gap
       const initPromise = reporter.init();
 
-      // Manually set state to test the failed path
       reporter.send({
         event: "playing",
         sessionId: "test-session-id",
@@ -459,7 +450,6 @@ describe("Reporter", () => {
         // Expected
       }
 
-      // After failure, send should warn
       mockFetch.calls.reset();
       spyOn(console, "warn");
 
@@ -476,17 +466,15 @@ describe("Reporter", () => {
     });
 
     it("should not allow double init", async () => {
-      const options: IReporterOptions = {
+      const reporter = new Reporter({
         eventsinkUrl: "https://example.com/analytics",
         sessionId: "test-session-id",
         debug: true,
-      };
-      const reporter = new Reporter(options);
+      });
 
       const result1 = await reporter.init();
       const result2 = await reporter.init();
 
-      // Second call should return same promise/result
       expect(result1.sessionId).toBe(result2.sessionId);
     });
   });

--- a/src/PlayerAnalytics.ts
+++ b/src/PlayerAnalytics.ts
@@ -17,7 +17,7 @@ import {
   TWarningEvent,
 } from "@eyevinn/player-analytics-specification";
 import { HEARTBEAT_INTERVAL } from "./utils/constants";
-import { Reporter } from "./utils/Reporter";
+import { Reporter, TOnSendError } from "./utils/Reporter";
 
 export interface IPlayerAnalyticsInitOptions {
   sessionId?: string;
@@ -29,9 +29,11 @@ export class PlayerAnalytics implements PlayerAnalyticsClientModule {
   private debug = false;
   private eventsinkUrl: string;
   private analyticsReporter: Reporter;
-  constructor(eventsinkUrl: string, debug?: boolean) {
+  private onError?: TOnSendError;
+  constructor(eventsinkUrl: string, debug?: boolean, onError?: TOnSendError) {
     this.debug = debug ?? false;
     this.eventsinkUrl = eventsinkUrl;
+    this.onError = onError;
   }
 
   public async initiateAnalyticsReporter({
@@ -45,6 +47,7 @@ export class PlayerAnalytics implements PlayerAnalyticsClientModule {
       debug: this.debug,
       heartbeatInterval,
       shardId,
+      onError: this.onError,
     });
 
     const { sessionId: generatedSessionId, isInitiated } =

--- a/src/PlayerAnalytics.ts
+++ b/src/PlayerAnalytics.ts
@@ -140,6 +140,11 @@ export class PlayerAnalytics implements PlayerAnalyticsClientModule {
   }
 
   public destroy() {
+    // Cascade destroy to the reporter so any in-flight init is aborted
+    // and queued events are discarded rather than flushed.
+    if (this.analyticsReporter) {
+      this.analyticsReporter.destroy();
+    }
     this.analyticsReporter = null;
   }
 }

--- a/src/PlayerAnalytics.ts
+++ b/src/PlayerAnalytics.ts
@@ -58,7 +58,9 @@ export class PlayerAnalytics implements PlayerAnalyticsClientModule {
 
   private ensureReporter(): boolean {
     if (!this.analyticsReporter) {
-      console.warn('[PlayerAnalytics] Not initialized. Call initiateAnalyticsReporter() first.');
+      console.warn(
+        "[PlayerAnalytics] Not initialized. Call initiateAnalyticsReporter() first."
+      );
       return false;
     }
     return true;

--- a/src/PlayerAnalyticsConnector.ts
+++ b/src/PlayerAnalyticsConnector.ts
@@ -40,7 +40,11 @@ export class PlayerAnalyticsConnector {
 
   constructor(eventsinkUrl: string, debug?: boolean, onError?: TOnSendError) {
     this.eventsinkUrl = eventsinkUrl;
-    this.playerAnalytics = new PlayerAnalytics(this.eventsinkUrl, debug, onError);
+    this.playerAnalytics = new PlayerAnalytics(
+      this.eventsinkUrl,
+      debug,
+      onError
+    );
   }
 
   public async init(options: IPlayerAnalyticsConnectorInitOptions) {
@@ -53,27 +57,30 @@ export class PlayerAnalyticsConnector {
       sessionId: this.sessionId,
     });
 
-    initPromise.then((result) => {
-      // Ignore stale init completions (e.g., if destroy() was called during init)
-      if (currentGeneration !== this.initGeneration) return;
+    initPromise
+      .then((result) => {
+        // Ignore stale init completions (e.g., if destroy() was called during init)
+        if (currentGeneration !== this.initGeneration) return;
 
-      this.analyticsInitiated = result.isInitiated === true;
-      this.heartbeatInterval = Number(result.heartbeatInterval) || this.heartbeatInterval;
-      if (typeof result.sessionId === "string" && result.sessionId) {
-        this.sessionId = result.sessionId;
-      }
-      if (this.pendingHeartbeatStart) {
+        this.analyticsInitiated = result.isInitiated === true;
+        this.heartbeatInterval =
+          Number(result.heartbeatInterval) || this.heartbeatInterval;
+        if (typeof result.sessionId === "string" && result.sessionId) {
+          this.sessionId = result.sessionId;
+        }
+        if (this.pendingHeartbeatStart) {
+          this.pendingHeartbeatStart = false;
+          this.startInterval();
+        }
+      })
+      .catch((err: unknown) => {
+        if (currentGeneration !== this.initGeneration) return;
+        // Reset pendingHeartbeatStart so a retry doesn't fire heartbeats
+        // from a stale flag without a new PLAYING event.
         this.pendingHeartbeatStart = false;
-        this.startInterval();
-      }
-    }).catch((err: unknown) => {
-      if (currentGeneration !== this.initGeneration) return;
-      // Reset pendingHeartbeatStart so a retry doesn't fire heartbeats
-      // from a stale flag without a new PLAYING event.
-      this.pendingHeartbeatStart = false;
-      const message = err instanceof Error ? err.message : String(err);
-      console.warn("[PlayerAnalyticsConnector] Init failed:", message);
-    });
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn("[PlayerAnalyticsConnector] Init failed:", message);
+      });
 
     return initPromise;
   }
@@ -240,7 +247,9 @@ export class PlayerAnalyticsConnector {
         ? this.player.duration
         : -1;
     const playhead =
-      this.player?.currentTime != null && this.player.currentTime >= 0 && duration !== -1
+      this.player?.currentTime != null &&
+      this.player.currentTime >= 0 &&
+      duration !== -1
         ? this.player?.currentTime
         : -1;
     return {

--- a/src/PlayerAnalyticsConnector.ts
+++ b/src/PlayerAnalyticsConnector.ts
@@ -29,9 +29,10 @@ export class PlayerAnalyticsConnector {
   private playerAnalytics: PlayerAnalytics;
   private analyticsInitiated = false;
   private initCalled = false;
+  private initGeneration = 0;
 
   private videoEventFilter: TMediaEventFilter;
-  private videoEventListener: any;
+  private videoEventListener: unknown;
 
   private heartbeatInterval: number;
   private heartbeatIntervalTimer: ReturnType<typeof setInterval>;
@@ -45,24 +46,30 @@ export class PlayerAnalyticsConnector {
   public async init(options: IPlayerAnalyticsConnectorInitOptions) {
     this.sessionId = options.sessionId;
     this.initCalled = true;
+    const currentGeneration = ++this.initGeneration;
 
     const initPromise = this.playerAnalytics.initiateAnalyticsReporter({
       ...options,
       sessionId: this.sessionId,
     });
 
-    initPromise.then(({ heartbeatInterval, isInitiated, sessionId }) => {
-      this.analyticsInitiated = isInitiated;
-      this.heartbeatInterval = heartbeatInterval;
-      if (sessionId) {
-        this.sessionId = sessionId;
+    initPromise.then((result) => {
+      // Ignore stale init completions (e.g., if destroy() was called during init)
+      if (currentGeneration !== this.initGeneration) return;
+
+      this.analyticsInitiated = result.isInitiated === true;
+      this.heartbeatInterval = Number(result.heartbeatInterval) || this.heartbeatInterval;
+      if (typeof result.sessionId === "string" && result.sessionId) {
+        this.sessionId = result.sessionId;
       }
       if (this.pendingHeartbeatStart) {
         this.pendingHeartbeatStart = false;
         this.startInterval();
       }
-    }).catch((err) => {
-      console.warn("[PlayerAnalyticsConnector] Init failed:", err.message);
+    }).catch((err: unknown) => {
+      if (currentGeneration !== this.initGeneration) return;
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn("[PlayerAnalyticsConnector] Init failed:", message);
     });
 
     return initPromise;
@@ -246,6 +253,7 @@ export class PlayerAnalyticsConnector {
       console.warn("[PlayerAnalyticsConnector] Analytics not initiated");
       return;
     }
+    this.initGeneration++; // Invalidate any pending init callbacks
     this.stopInterval();
     this.heartbeatInterval = null;
     this.videoEventFilter && this.videoEventFilter.teardown();
@@ -259,6 +267,7 @@ export class PlayerAnalyticsConnector {
       console.warn("[PlayerAnalyticsConnector] Analytics not initiated");
       return;
     }
+    this.initGeneration++; // Invalidate any pending init callbacks
     this.stopInterval();
     this.playerAnalytics.destroy();
     this.heartbeatInterval = null;

--- a/src/PlayerAnalyticsConnector.ts
+++ b/src/PlayerAnalyticsConnector.ts
@@ -68,6 +68,9 @@ export class PlayerAnalyticsConnector {
       }
     }).catch((err: unknown) => {
       if (currentGeneration !== this.initGeneration) return;
+      // Reset pendingHeartbeatStart so a retry doesn't fire heartbeats
+      // from a stale flag without a new PLAYING event.
+      this.pendingHeartbeatStart = false;
       const message = err instanceof Error ? err.message : String(err);
       console.warn("[PlayerAnalyticsConnector] Init failed:", message);
     });

--- a/src/PlayerAnalyticsConnector.ts
+++ b/src/PlayerAnalyticsConnector.ts
@@ -4,6 +4,7 @@ import {
   TMediaEventFilter,
 } from "@eyevinn/media-event-filter";
 import { PlayerAnalytics } from "./PlayerAnalytics";
+import { TOnSendError } from "./utils/Reporter";
 import {
   TBaseEvent,
   TBitrateChangedEventPayload,
@@ -27,28 +28,44 @@ export class PlayerAnalyticsConnector {
 
   private playerAnalytics: PlayerAnalytics;
   private analyticsInitiated = false;
+  private initCalled = false;
 
   private videoEventFilter: TMediaEventFilter;
   private videoEventListener: any;
 
   private heartbeatInterval: number;
   private heartbeatIntervalTimer: ReturnType<typeof setInterval>;
+  private pendingHeartbeatStart = false;
 
-  constructor(eventsinkUrl: string, debug?: boolean) {
+  constructor(eventsinkUrl: string, debug?: boolean, onError?: TOnSendError) {
     this.eventsinkUrl = eventsinkUrl;
-    this.playerAnalytics = new PlayerAnalytics(this.eventsinkUrl, debug);
+    this.playerAnalytics = new PlayerAnalytics(this.eventsinkUrl, debug, onError);
   }
 
   public async init(options: IPlayerAnalyticsConnectorInitOptions) {
     this.sessionId = options.sessionId;
-    const { heartbeatInterval, isInitiated } =
-      await this.playerAnalytics.initiateAnalyticsReporter({
-        ...options,
-        sessionId: this.sessionId,
-      });
+    this.initCalled = true;
 
-    this.analyticsInitiated = isInitiated;
-    this.heartbeatInterval = heartbeatInterval;
+    const initPromise = this.playerAnalytics.initiateAnalyticsReporter({
+      ...options,
+      sessionId: this.sessionId,
+    });
+
+    initPromise.then(({ heartbeatInterval, isInitiated, sessionId }) => {
+      this.analyticsInitiated = isInitiated;
+      this.heartbeatInterval = heartbeatInterval;
+      if (sessionId) {
+        this.sessionId = sessionId;
+      }
+      if (this.pendingHeartbeatStart) {
+        this.pendingHeartbeatStart = false;
+        this.startInterval();
+      }
+    }).catch((err) => {
+      console.warn("[PlayerAnalyticsConnector] Init failed:", err.message);
+    });
+
+    return initPromise;
   }
 
   public load(player: HTMLVideoElement) {
@@ -100,7 +117,7 @@ export class PlayerAnalyticsConnector {
             break;
         }
         try {
-          if (!this.analyticsInitiated) {
+          if (!this.initCalled) {
             console.warn("[PlayerAnalyticsConnector] Analytics not initiated");
             return;
           }
@@ -120,6 +137,10 @@ export class PlayerAnalyticsConnector {
 
   private startInterval() {
     if (this.heartbeatIntervalTimer) return;
+    if (!this.heartbeatInterval) {
+      this.pendingHeartbeatStart = true;
+      return;
+    }
     this.heartbeatIntervalTimer = setInterval(() => {
       this.playerAnalytics.heartbeat({
         event: "heartbeat",
@@ -131,10 +152,11 @@ export class PlayerAnalyticsConnector {
   private stopInterval() {
     clearInterval(this.heartbeatIntervalTimer);
     this.heartbeatIntervalTimer = null;
+    this.pendingHeartbeatStart = false;
   }
 
   public reportBitrateChange(payload: TBitrateChangedEventPayload) {
-    if (!this.analyticsInitiated) {
+    if (!this.initCalled) {
       console.warn("[PlayerAnalyticsConnector] Analytics not initiated");
       return;
     }
@@ -146,7 +168,7 @@ export class PlayerAnalyticsConnector {
   }
 
   public reportStop() {
-    if (!this.analyticsInitiated) {
+    if (!this.initCalled) {
       console.warn("[PlayerAnalyticsConnector] Analytics not initiated");
       return;
     }
@@ -159,7 +181,7 @@ export class PlayerAnalyticsConnector {
   }
 
   public reportError(error: TErrorEventPayload) {
-    if (!this.analyticsInitiated) {
+    if (!this.initCalled) {
       console.warn("[PlayerAnalyticsConnector] Analytics not initiated");
       return;
     }
@@ -177,7 +199,7 @@ export class PlayerAnalyticsConnector {
   }
 
   public reportMetadata(payload: TMetadataEventPayload) {
-    if (!this.analyticsInitiated) {
+    if (!this.initCalled) {
       console.warn("[PlayerAnalyticsConnector] Analytics not initiated");
       return;
     }
@@ -189,7 +211,7 @@ export class PlayerAnalyticsConnector {
   }
 
   public reportWarning(payload: TWarningEventPayload) {
-    if (!this.analyticsInitiated) {
+    if (!this.initCalled) {
       console.warn("[PlayerAnalyticsConnector] Analytics not initiated");
       return;
     }
@@ -220,7 +242,7 @@ export class PlayerAnalyticsConnector {
   }
 
   public deinit() {
-    if (!this.analyticsInitiated) {
+    if (!this.initCalled) {
       console.warn("[PlayerAnalyticsConnector] Analytics not initiated");
       return;
     }
@@ -229,10 +251,11 @@ export class PlayerAnalyticsConnector {
     this.videoEventFilter && this.videoEventFilter.teardown();
     this.videoEventFilter = null;
     this.analyticsInitiated = false;
+    this.initCalled = false;
   }
 
   public destroy() {
-    if (!this.analyticsInitiated) {
+    if (!this.initCalled) {
       console.warn("[PlayerAnalyticsConnector] Analytics not initiated");
       return;
     }
@@ -242,5 +265,6 @@ export class PlayerAnalyticsConnector {
     this.videoEventFilter && this.videoEventFilter.teardown();
     this.videoEventFilter = null;
     this.analyticsInitiated = false;
+    this.initCalled = false;
   }
 }

--- a/src/PlayerAnalyticsConnector.ts
+++ b/src/PlayerAnalyticsConnector.ts
@@ -257,6 +257,10 @@ export class PlayerAnalyticsConnector {
       return;
     }
     this.initGeneration++; // Invalidate any pending init callbacks
+    // Abort any in-flight init so queued events don't flush after teardown.
+    // The next init() call creates a fresh Reporter, so destroying the
+    // current one is safe even though deinit is meant to be reusable.
+    this.playerAnalytics.destroy();
     this.stopInterval();
     this.heartbeatInterval = null;
     this.videoEventFilter && this.videoEventFilter.teardown();

--- a/src/utils/Reporter.ts
+++ b/src/utils/Reporter.ts
@@ -4,12 +4,28 @@ import {
 } from "@eyevinn/player-analytics-specification";
 import { EPAS_VERSION, HEARTBEAT_INTERVAL } from "./constants";
 
+export type TAnalyticsSendError = {
+  status?: number;
+  statusText?: string;
+  message: string;
+};
+
+export type TOnSendError = (
+  error: TAnalyticsSendError,
+  event: TPlayerAnalyticsEvent
+) => void;
+
+type ReporterState = "idle" | "initializing" | "ready" | "failed";
+
+const MAX_QUEUE_SIZE = 100;
+
 export interface IReporterOptions {
   eventsinkUrl: string;
   heartbeatInterval?: number;
   sessionId?: string;
   shardId?: string;
   debug?: boolean;
+  onError?: TOnSendError;
 }
 
 export interface IReporterPostOptions {
@@ -25,7 +41,10 @@ export class Reporter {
   private sessionId?: string;
   private shardId?: string;
   private heartbeatInterval?: number;
-  private isInitiated = false;
+  private state: ReporterState = "idle";
+  private eventQueue: TPlayerAnalyticsEvent[] = [];
+  private initPromise: Promise<Record<string, any>> | null = null;
+  private onError?: TOnSendError;
 
   constructor(options: IReporterOptions) {
     this.debug = options.debug ?? false;
@@ -33,14 +52,25 @@ export class Reporter {
     this.eventsinkUrl = options.eventsinkUrl;
     this.sessionId = options.sessionId;
     this.heartbeatInterval = options.heartbeatInterval || HEARTBEAT_INTERVAL;
+    this.onError = options.onError;
 
     if (this.debug) {
       console.log("[AnalyticsReporter] Initiated AnalyticsReporter", options);
     }
   }
 
+  public get isInitiated(): boolean {
+    return this.state === "ready";
+  }
+
   public async init(sessionId?: string): Promise<Record<string, any>> {
+    if (this.state !== "idle") {
+      return this.initPromise!;
+    }
+
     this.sessionId = sessionId || this.sessionId;
+    this.state = "initializing";
+
     const data: TInitEvent = {
       event: "init",
       sessionId: this.sessionId,
@@ -49,15 +79,26 @@ export class Reporter {
       playhead: -1,
       duration: -1,
     };
+
     if (this.debug) {
       console.log("[AnalyticsReporter] Init session:", data);
-      this.isInitiated = true;
-      return {
+      this.state = "ready";
+      this.flushQueue();
+      const result = {
         sessionId: this.sessionId,
         heartbeatInterval: this.heartbeatInterval,
-        isInitiated: this.isInitiated,
+        isInitiated: true,
       };
-    } else {
+      this.initPromise = Promise.resolve(result);
+      return this.initPromise;
+    }
+
+    this.initPromise = this.doInit(data);
+    return this.initPromise;
+  }
+
+  private async doInit(data: TInitEvent): Promise<Record<string, any>> {
+    try {
       const initResponse = await fetch(`${this.eventsinkUrl}`, {
         method: "POST",
         mode: "cors",
@@ -69,11 +110,13 @@ export class Reporter {
         },
         body: JSON.stringify(data),
       });
+
       if (!initResponse.ok) {
         throw new Error(
           `[AnalyticsReporter] init failed: ${initResponse.statusText}`
         );
       }
+
       const initResponseJson = await initResponse.json();
 
       if (!this.sessionId && !initResponseJson.sessionId) {
@@ -82,25 +125,54 @@ export class Reporter {
       if (initResponseJson.sessionId) {
         this.sessionId = initResponseJson.sessionId;
       }
-      this.isInitiated = true;
+
+      this.state = "ready";
+      this.flushQueue();
+
       return {
         heartbeatInterval: this.heartbeatInterval,
         sessionId: this.sessionId,
-        isInitiated: this.isInitiated,
+        isInitiated: true,
       };
+    } catch (err) {
+      this.state = "failed";
+      this.eventQueue = [];
+      throw err;
     }
   }
 
   public send(data: TPlayerAnalyticsEvent): void {
-    if (!this.isInitiated)
-      return console.warn(
-        "[AnalyticsReporter] Cannot report before initiation:",
-        data
-      );
+    switch (this.state) {
+      case "ready":
+        this.dispatch(data);
+        break;
+      case "initializing":
+        if (this.eventQueue.length >= MAX_QUEUE_SIZE) {
+          console.warn("[AnalyticsReporter] Event queue full, dropping oldest event");
+          this.eventQueue.shift();
+        }
+        this.eventQueue.push(data);
+        break;
+      case "idle":
+        console.warn(
+          "[AnalyticsReporter] Cannot report before initiation:",
+          data
+        );
+        break;
+      case "failed":
+        console.warn(
+          "[AnalyticsReporter] Init failed, cannot send:",
+          data
+        );
+        break;
+    }
+  }
+
+  private dispatch(data: TPlayerAnalyticsEvent): void {
     const payload = {
+      ...data,
       sessionId: this.sessionId,
       shardId: this.shardId,
-      ...data,
     };
     if (this.debug) {
       console.log("[AnalyticsReporter] Send payload:", payload);
@@ -117,11 +189,35 @@ export class Reporter {
         body: JSON.stringify(payload),
       }).then((res) => {
         if (res && !res.ok) {
-          console.warn(`[AnalyticsReporter] Send failed: ${res.status} ${res.statusText}`);
+          const error: TAnalyticsSendError = {
+            status: res.status,
+            statusText: res.statusText,
+            message: `Send failed: ${res.status} ${res.statusText}`,
+          };
+          if (this.onError) {
+            this.onError(error, data);
+          } else {
+            console.warn(`[AnalyticsReporter] ${error.message}`);
+          }
         }
       }).catch((err) => {
-        console.warn('[AnalyticsReporter] Send failed:', err.message);
+        const error: TAnalyticsSendError = {
+          message: err.message,
+        };
+        if (this.onError) {
+          this.onError(error, data);
+        } else {
+          console.warn("[AnalyticsReporter] Send failed:", err.message);
+        }
       });
+    }
+  }
+
+  private flushQueue(): void {
+    const queued = this.eventQueue;
+    this.eventQueue = [];
+    for (const event of queued) {
+      this.dispatch(event);
     }
   }
 }

--- a/src/utils/Reporter.ts
+++ b/src/utils/Reporter.ts
@@ -15,7 +15,7 @@ export type TOnSendError = (
   event: TPlayerAnalyticsEvent
 ) => void;
 
-type ReporterState = "idle" | "initializing" | "ready" | "failed";
+type ReporterState = "idle" | "initializing" | "ready" | "failed" | "destroyed";
 
 const MAX_QUEUE_SIZE = 100;
 
@@ -111,6 +111,11 @@ export class Reporter {
         body: JSON.stringify(data),
       });
 
+      // Abort if destroy() was called during the await
+      if ((this.state as ReporterState) === "destroyed") {
+        throw new Error("[AnalyticsReporter] init aborted: reporter was destroyed");
+      }
+
       if (!initResponse.ok) {
         throw new Error(
           `[AnalyticsReporter] init failed: ${initResponse.statusText}`
@@ -118,6 +123,10 @@ export class Reporter {
       }
 
       const initResponseJson = await initResponse.json();
+
+      if ((this.state as ReporterState) === "destroyed") {
+        throw new Error("[AnalyticsReporter] init aborted: reporter was destroyed");
+      }
 
       if (!this.sessionId && !initResponseJson.sessionId) {
         throw new Error(`[AnalyticsReporter] init failed: no sessionId`);
@@ -131,9 +140,16 @@ export class Reporter {
       // iteration). This prevents new events from interleaving with the
       // queued chain on the wire.
       while (this.eventQueue.length > 0) {
+        if ((this.state as ReporterState) === "destroyed") {
+          throw new Error("[AnalyticsReporter] init aborted: reporter was destroyed");
+        }
         await this.flushQueue();
       }
-      this.state = "ready";
+
+      // Don't transition to ready if destroyed during flush
+      if ((this.state as ReporterState) !== "destroyed") {
+        this.state = "ready";
+      }
 
       return {
         heartbeatInterval: this.heartbeatInterval,
@@ -141,7 +157,10 @@ export class Reporter {
         isInitiated: true,
       };
     } catch (err) {
-      this.state = "failed";
+      // Don't overwrite 'destroyed' state with 'failed'
+      if ((this.state as ReporterState) !== "destroyed") {
+        this.state = "failed";
+      }
       this.eventQueue = [];
       throw err;
     }
@@ -170,6 +189,9 @@ export class Reporter {
           "[AnalyticsReporter] Init failed, cannot send:",
           data
         );
+        break;
+      case "destroyed":
+        // Silently drop — consumer has torn down, no need to warn
         break;
     }
   }
@@ -224,7 +246,19 @@ export class Reporter {
     this.eventQueue = [];
     // Serialize sends to preserve event order on the wire
     for (const event of queued) {
+      // Abort if destroy() was called mid-flush
+      if (this.state === "destroyed") return;
       await this.dispatch(event);
     }
+  }
+
+  /**
+   * Tear down the reporter. Aborts any in-flight init, discards queued
+   * events without flushing, and prevents future send() calls from
+   * dispatching. Called by PlayerAnalytics.destroy().
+   */
+  public destroy(): void {
+    this.state = "destroyed";
+    this.eventQueue = [];
   }
 }

--- a/src/utils/Reporter.ts
+++ b/src/utils/Reporter.ts
@@ -43,7 +43,7 @@ export class Reporter {
   private heartbeatInterval?: number;
   private state: ReporterState = "idle";
   private eventQueue: TPlayerAnalyticsEvent[] = [];
-  private initPromise: Promise<Record<string, any>> | null = null;
+  private initPromise: Promise<Record<string, unknown>> | null = null;
   private onError?: TOnSendError;
 
   constructor(options: IReporterOptions) {
@@ -63,7 +63,7 @@ export class Reporter {
     return this.state === "ready";
   }
 
-  public async init(sessionId?: string): Promise<Record<string, any>> {
+  public async init(sessionId?: string): Promise<Record<string, unknown>> {
     if (this.state !== "idle") {
       return this.initPromise!;
     }
@@ -97,7 +97,7 @@ export class Reporter {
     return this.initPromise;
   }
 
-  private async doInit(data: TInitEvent): Promise<Record<string, any>> {
+  private async doInit(data: TInitEvent): Promise<Record<string, unknown>> {
     try {
       const initResponse = await fetch(`${this.eventsinkUrl}`, {
         method: "POST",
@@ -148,8 +148,8 @@ export class Reporter {
         break;
       case "initializing":
         if (this.eventQueue.length >= MAX_QUEUE_SIZE) {
-          console.warn("[AnalyticsReporter] Event queue full, dropping oldest event");
-          this.eventQueue.shift();
+          console.warn("[AnalyticsReporter] Event queue full, dropping newest event");
+          break;
         }
         this.eventQueue.push(data);
         break;
@@ -168,7 +168,7 @@ export class Reporter {
     }
   }
 
-  private dispatch(data: TPlayerAnalyticsEvent): void {
+  private dispatch(data: TPlayerAnalyticsEvent): Promise<void> {
     const payload = {
       ...data,
       sessionId: this.sessionId,
@@ -176,48 +176,50 @@ export class Reporter {
     };
     if (this.debug) {
       console.log("[AnalyticsReporter] Send payload:", payload);
-    } else {
-      fetch(`${this.eventsinkUrl}`, {
-        method: "POST",
-        mode: "cors",
-        cache: "no-cache",
-        headers: {
-          "Content-Type": "application/json; charset=utf-8",
-          "X-EPAS-Event": data.event,
-          "X-EPAS-Version": EPAS_VERSION,
-        },
-        body: JSON.stringify(payload),
-      }).then((res) => {
-        if (res && !res.ok) {
-          const error: TAnalyticsSendError = {
-            status: res.status,
-            statusText: res.statusText,
-            message: `Send failed: ${res.status} ${res.statusText}`,
-          };
-          if (this.onError) {
-            this.onError(error, data);
-          } else {
-            console.warn(`[AnalyticsReporter] ${error.message}`);
-          }
-        }
-      }).catch((err) => {
+      return Promise.resolve();
+    }
+    return fetch(`${this.eventsinkUrl}`, {
+      method: "POST",
+      mode: "cors",
+      cache: "no-cache",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "X-EPAS-Event": data.event,
+        "X-EPAS-Version": EPAS_VERSION,
+      },
+      body: JSON.stringify(payload),
+    }).then((res) => {
+      if (res && !res.ok) {
         const error: TAnalyticsSendError = {
-          message: err.message,
+          status: res.status,
+          statusText: res.statusText,
+          message: `Send failed: ${res.status} ${res.statusText}`,
         };
         if (this.onError) {
           this.onError(error, data);
         } else {
-          console.warn("[AnalyticsReporter] Send failed:", err.message);
+          console.warn(`[AnalyticsReporter] ${error.message}`);
         }
-      });
-    }
+      }
+    }).catch((err) => {
+      const error: TAnalyticsSendError = {
+        message: err instanceof Error ? err.message : String(err),
+      };
+      if (this.onError) {
+        this.onError(error, data);
+      } else {
+        console.warn("[AnalyticsReporter] Send failed:", error.message);
+      }
+    });
   }
 
   private flushQueue(): void {
     const queued = this.eventQueue;
     this.eventQueue = [];
+    // Serialize sends to preserve event order on the wire
+    let chain = Promise.resolve();
     for (const event of queued) {
-      this.dispatch(event);
+      chain = chain.then(() => this.dispatch(event));
     }
   }
 }

--- a/src/utils/Reporter.ts
+++ b/src/utils/Reporter.ts
@@ -113,7 +113,9 @@ export class Reporter {
 
       // Abort if destroy() was called during the await
       if ((this.state as ReporterState) === "destroyed") {
-        throw new Error("[AnalyticsReporter] init aborted: reporter was destroyed");
+        throw new Error(
+          "[AnalyticsReporter] init aborted: reporter was destroyed"
+        );
       }
 
       if (!initResponse.ok) {
@@ -125,7 +127,9 @@ export class Reporter {
       const initResponseJson = await initResponse.json();
 
       if ((this.state as ReporterState) === "destroyed") {
-        throw new Error("[AnalyticsReporter] init aborted: reporter was destroyed");
+        throw new Error(
+          "[AnalyticsReporter] init aborted: reporter was destroyed"
+        );
       }
 
       if (!this.sessionId && !initResponseJson.sessionId) {
@@ -141,7 +145,9 @@ export class Reporter {
       // queued chain on the wire.
       while (this.eventQueue.length > 0) {
         if ((this.state as ReporterState) === "destroyed") {
-          throw new Error("[AnalyticsReporter] init aborted: reporter was destroyed");
+          throw new Error(
+            "[AnalyticsReporter] init aborted: reporter was destroyed"
+          );
         }
         await this.flushQueue();
       }
@@ -173,7 +179,9 @@ export class Reporter {
         break;
       case "initializing":
         if (this.eventQueue.length >= MAX_QUEUE_SIZE) {
-          console.warn("[AnalyticsReporter] Event queue full, dropping newest event");
+          console.warn(
+            "[AnalyticsReporter] Event queue full, dropping newest event"
+          );
           break;
         }
         this.eventQueue.push(data);
@@ -185,10 +193,7 @@ export class Reporter {
         );
         break;
       case "failed":
-        console.warn(
-          "[AnalyticsReporter] Init failed, cannot send:",
-          data
-        );
+        console.warn("[AnalyticsReporter] Init failed, cannot send:", data);
         break;
       case "destroyed":
         // Silently drop — consumer has torn down, no need to warn
@@ -216,29 +221,31 @@ export class Reporter {
         "X-EPAS-Version": EPAS_VERSION,
       },
       body: JSON.stringify(payload),
-    }).then((res) => {
-      if (res && !res.ok) {
+    })
+      .then((res) => {
+        if (res && !res.ok) {
+          const error: TAnalyticsSendError = {
+            status: res.status,
+            statusText: res.statusText,
+            message: `Send failed: ${res.status} ${res.statusText}`,
+          };
+          if (this.onError) {
+            this.onError(error, data);
+          } else {
+            console.warn(`[AnalyticsReporter] ${error.message}`);
+          }
+        }
+      })
+      .catch((err) => {
         const error: TAnalyticsSendError = {
-          status: res.status,
-          statusText: res.statusText,
-          message: `Send failed: ${res.status} ${res.statusText}`,
+          message: err instanceof Error ? err.message : String(err),
         };
         if (this.onError) {
           this.onError(error, data);
         } else {
-          console.warn(`[AnalyticsReporter] ${error.message}`);
+          console.warn("[AnalyticsReporter] Send failed:", error.message);
         }
-      }
-    }).catch((err) => {
-      const error: TAnalyticsSendError = {
-        message: err instanceof Error ? err.message : String(err),
-      };
-      if (this.onError) {
-        this.onError(error, data);
-      } else {
-        console.warn("[AnalyticsReporter] Send failed:", error.message);
-      }
-    });
+      });
   }
 
   private async flushQueue(): Promise<void> {

--- a/src/utils/Reporter.ts
+++ b/src/utils/Reporter.ts
@@ -126,8 +126,14 @@ export class Reporter {
         this.sessionId = initResponseJson.sessionId;
       }
 
+      // Stay in 'initializing' while flushing so that any new send() calls
+      // during flush continue to enqueue (and get flushed in the next loop
+      // iteration). This prevents new events from interleaving with the
+      // queued chain on the wire.
+      while (this.eventQueue.length > 0) {
+        await this.flushQueue();
+      }
       this.state = "ready";
-      this.flushQueue();
 
       return {
         heartbeatInterval: this.heartbeatInterval,
@@ -213,13 +219,12 @@ export class Reporter {
     });
   }
 
-  private flushQueue(): void {
+  private async flushQueue(): Promise<void> {
     const queued = this.eventQueue;
     this.eventQueue = [];
     // Serialize sends to preserve event order on the wire
-    let chain = Promise.resolve();
     for (const event of queued) {
-      chain = chain.then(() => this.dispatch(event));
+      await this.dispatch(event);
     }
   }
 }


### PR DESCRIPTION
## Summary
Addresses #17 (reopened by @martinstark). Analytics init no longer blocks video playback.

- **Reporter state machine** (`idle → initializing → ready/failed`) replaces boolean `isInitiated`
- **Event queue** (capped at 100) — events sent during init are queued and flushed with server sessionId once init completes
- **Deferred heartbeat** — if PLAYING fires before init resolves, heartbeat starts automatically when init completes
- **onError callback** — optional `TOnSendError` callback for consumers to handle send failures (also closes #16)
- **Exported types** — `TAnalyticsSendError` and `TOnSendError`
- **SessionId fix** — Connector now updates sessionId from server response (was a bug)
- **Backwards compatible** — `await connector.init()` still works identically

Closes #17

## Test plan
- [x] 66 specs passing, `npx tsc` clean
- [x] Events queued during init flush in order with correct sessionId
- [x] Queue discarded on init failure
- [x] load() before init resolves → loading event queued
- [x] Heartbeat deferred until init completes
- [x] await init() backwards compat
- [x] onError callback on network failure and HTTP 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)